### PR TITLE
feat(thanos): support setting annotation on secret

### DIFF
--- a/charts/thanos/CHANGELOG.md
+++ b/charts/thanos/CHANGELOG.md
@@ -15,6 +15,12 @@
 
 ## [UNRELEASED]
 
+## [v0.8.0] - 2025-11-19
+
+### Added
+
+- Support setting annotations on objstore secret
+
 ## [v0.7.0] - 2025-11-17
 
 ### Changed

--- a/charts/thanos/Chart.yaml
+++ b/charts/thanos/Chart.yaml
@@ -3,7 +3,7 @@ name: thanos
 description: |
   Thanos Helm chart for Kubernetes.
 type: application
-version: 0.7.0
+version: 0.8.0
 appVersion: v0.40.1
 keywords:
   - kubernetes

--- a/charts/thanos/README.md
+++ b/charts/thanos/README.md
@@ -1,6 +1,6 @@
 # thanos
 
-![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: v0.40.1](https://img.shields.io/badge/AppVersion-v0.40.1-informational?style=flat-square)  [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/solidcharts)](https://artifacthub.io/packages/search?repo=solidcharts)
+![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square)  ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)  ![AppVersion: v0.40.1](https://img.shields.io/badge/AppVersion-v0.40.1-informational?style=flat-square)  [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/solidcharts)](https://artifacthub.io/packages/search?repo=solidcharts)
 
 ## Description
 
@@ -27,7 +27,7 @@ This chart is a replacement for Bitnami Thanos chart.
 To install the chart you can use the following command:
 
 ```shell
-helm upgrade --install thanos oci://ghcr.io/solidcharts/helm-charts/thanos --version 0.7.0
+helm upgrade --install thanos oci://ghcr.io/solidcharts/helm-charts/thanos --version 0.8.0
 ```
 
 ### Non-OCI Repository
@@ -37,7 +37,7 @@ Alternatively, you can use the legacy non-OCI method via the following commands:
 ```shell
 helm repo add solidcharts https://solidcharts.github.io/helm-charts/
 helm repo update
-helm upgrade --install thanos solidcharts/thanos --version 0.7.0
+helm upgrade --install thanos solidcharts/thanos --version 0.8.0
 ```
 
 ## Requirements
@@ -146,6 +146,7 @@ helm upgrade --install thanos solidcharts/thanos --version 0.7.0
 | logFormat | string | `"logfmt"` | Log format for _Thanos_ components. |
 | logLevel | string | `"info"` | Log level for _Thanos_ components. |
 | nameOverride | string | `nil` |  |
+| objstoreConfig.annotations | object | `{}` | Annotations to add to the objstore secret, if it is created. |
 | objstoreConfig.create | bool | `true` | If `true`, create a `Secret` for the objstore store configuration. |
 | objstoreConfig.key | string | `"config"` | Secret key for the objstore configuration. |
 | objstoreConfig.name | string | `nil` | If this is set and `objstoreConfig.create` is `true` this will be used for the created secret name, if this is set and `objstoreConfig.create` is `false` then this will define an existing secret to use. |

--- a/charts/thanos/templates/secret-objstore-config.yaml
+++ b/charts/thanos/templates/secret-objstore-config.yaml
@@ -4,6 +4,10 @@ kind: Secret
 metadata:
   name: {{ include "thanos.objstoreConfigSecretName" . }}
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.objstoreConfig.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "shared.labels" . | nindent 4 }}
 data:

--- a/charts/thanos/values.yaml
+++ b/charts/thanos/values.yaml
@@ -41,6 +41,8 @@ clusterDomain: cluster.local
 objstoreConfig:
   # -- If `true`, create a `Secret` for the objstore store configuration.
   create: true
+  # -- Annotations to add to the objstore secret, if it is created.
+  annotations: {}
   # -- (string) If this is set and `objstoreConfig.create` is `true` this will be used for the created secret name, if this is set and `objstoreConfig.create` is `false` then this will define an existing secret to use.
   name:
   # -- Secret key for the objstore configuration.


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

# Feature

Support adding annotations on secret

# Use case

In our system all secrets are by default handled in vault (using external secrets). But since in this case the secret actually doesn't include anything security sensitive I would like to opt out of that handling and I need to ad an anotation to opt out.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Variables are documented in the `values.yaml` and `README.md` has been updated (re-generated using helm-docs).
- [x] Title of the pull request follows conventional commits pattern using chart name as a scope (e.g. `feat(rabbitmq): some change`)
- [x] `CHANGELOG.md` has been updated with a description of the change (see `CHANGELOG.md` for details).`
- [x] [Optional] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes can wait until the next release.
